### PR TITLE
Fix referential integrity check

### DIFF
--- a/src/validation.py
+++ b/src/validation.py
@@ -336,7 +336,7 @@ class DataValidator:
         """
         Ensures that values in self.reference_columns exist in self.reference_data.
         """
-        if not self.reference_data or not self.reference_columns:
+        if self.reference_data is None or not self.reference_columns:
             log_activity("No reference data/columns, skipping referential checks.", level='info')
             return
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -179,5 +179,36 @@ class TestValidationModule(unittest.TestCase):
         self.assertIn(-5, integrity_df['Age'].values, "Negative Age (-5) wasn't captured in integrity issues.")
         self.assertIn("Unknown", integrity_df['Gender'].values, "'Unknown' gender wasn't captured in integrity issues.")
 
+    def test_referential_integrity_check(self):
+        """Ensure referential integrity check does not raise with valid reference data."""
+        ref_df = pd.DataFrame({"SampleID": ["S001", "S002", "S003", "S004"]})
+        validator = DataValidator(
+            self.df,
+            self.schema,
+            self.unique_identifiers,
+            reference_data=ref_df,
+            reference_columns=["SampleID"],
+        )
+        try:
+            validator.check_referential_integrity()
+        except Exception as e:
+            self.fail(f"check_referential_integrity raised an exception: {e}")
+        self.assertTrue(validator.referential_integrity_issues.empty)
+
+    def test_referential_integrity_missing_values(self):
+        """Rows with IDs absent from reference data should be reported."""
+        ref_df = pd.DataFrame({"SampleID": ["S001", "S002"]})
+        df_invalid = self.df.copy()
+        df_invalid.loc[3, "SampleID"] = "S999"
+        validator = DataValidator(
+            df_invalid,
+            self.schema,
+            self.unique_identifiers,
+            reference_data=ref_df,
+            reference_columns=["SampleID"],
+        )
+        validator.check_referential_integrity()
+        self.assertFalse(validator.referential_integrity_issues.empty)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -208,7 +208,9 @@ class TestValidationModule(unittest.TestCase):
             reference_columns=["SampleID"],
         )
         validator.check_referential_integrity()
-        self.assertFalse(validator.referential_integrity_issues.empty)
+        issues = validator.referential_integrity_issues
+        self.assertEqual(issues.shape[0], 1)
+        self.assertEqual(issues['SampleID'].iloc[0], "S999")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- fix bool check on pandas DataFrame in validation module
- add unit tests for referential integrity logic

## Testing
- `python -m unittest discover -v tests | head` *(fails: ModuleNotFoundError: No module named 'pandas')*

## Summary by Sourcery

Correct the referential integrity validation to properly detect the absence of reference data and add unit tests covering valid and missing reference cases.

Bug Fixes:
- Fix the truthiness check on pandas DataFrame in referential integrity to use `is None` instead of a boolean evaluation.

Tests:
- Add a unit test to verify that valid reference data does not raise integrity issues.
- Add a unit test to report missing IDs when they are absent from the reference data.