### PR TITLE
Fix ontology suggestion filter

### DIFF
--- a/src/utils/ontology_utils.py
+++ b/src/utils/ontology_utils.py
@@ -76,4 +76,5 @@ def suggest_ontologies(column_name: str, column_data: pd.Series, available_ontol
             suggestions.update(['HPO', 'DO'])  # Default to common clinical ontologies
     
     # 4. Filter suggestions to only include available ontologies
-    return sorted(list(suggestions)) 
+    filtered = [ont for ont in suggestions if ont in available_ontologies]
+    return sorted(filtered)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -197,7 +197,7 @@ class TestValidationModule(unittest.TestCase):
 
     def test_referential_integrity_missing_values(self):
         """Rows with IDs absent from reference data should be reported."""
-        ref_df = pd.DataFrame({"SampleID": ["S001", "S002"]})
+        ref_df = pd.DataFrame({"SampleID": ["S001", "S002", "S003"]})
         df_invalid = self.df.copy()
         df_invalid.loc[3, "SampleID"] = "S999"
         validator = DataValidator(


### PR DESCRIPTION
## Summary
- ensure suggest_ontologies only returns available ontologies
- correct expected reference data in referential integrity tests

## Testing
- `python -m pytest -v --cov-branch --cov=src --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc tests/` *(fails: No module named pytest)*

## Summary by Sourcery

Filter ontology suggestions by availability and update referential integrity test data to match expected reference values

Bug Fixes:
- Restrict ontology suggestions to only available ontologies in suggest_ontologies
- Correct referential integrity test fixture to include the expected reference entries