### PR TITLE
Handle empty identifier lists in traceability metric

### DIFF
--- a/src/quality_metrics.py
+++ b/src/quality_metrics.py
@@ -117,7 +117,7 @@ def check_traceability(
     df : pd.DataFrame
         Dataset to validate.
     id_cols : list of str
-        Columns that should uniquely identify a record.
+        Columns that should uniquely identify a record. Must not be empty.
     source_col : str, optional
         Column expected to contain non-null provenance information.
 
@@ -126,7 +126,15 @@ def check_traceability(
     pd.DataFrame
         Rows that violate traceability requirements with an ``issue`` column
         describing the problem.
+
+    Raises
+    ------
+    ValueError
+        If ``id_cols`` is empty.
     """
+    if not id_cols:
+        raise ValueError("id_cols must contain at least one column")
+
     records = []
     # Check for missing IDs or duplicates across id_cols combination
     dup_mask = df.duplicated(subset=id_cols, keep=False)

--- a/tests/test_quality_metrics.py
+++ b/tests/test_quality_metrics.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 from src.quality_metrics import (
     check_accuracy,
     detect_redundancy,
@@ -69,6 +70,12 @@ def test_check_traceability_duplicates_and_missing_source():
     result = check_traceability(df, ["id"], source_col="source")
     assert not result[result["issue"] == "duplicate_identifier"].empty
     assert not result[result["issue"] == "missing_source"].empty
+
+
+def test_check_traceability_empty_id_cols_raises():
+    df = pd.DataFrame({"id": [1, 2]})
+    with pytest.raises(ValueError):
+        check_traceability(df, [])
 
 
 def test_check_timeliness_flags_old_records():


### PR DESCRIPTION
## Summary
- validate `check_traceability` inputs by raising a `ValueError` when no identifier columns are supplied
- document empty identifier behaviour in `check_traceability` docstring
- test that `check_traceability` rejects empty identifier lists

## Testing
- `pytest`

## Summary by Sourcery

Enforce non-empty identifier list in check_traceability by raising a ValueError, update the docstring to document this behavior, and add a test for the empty identifier case

New Features:
- Raise a ValueError in check_traceability when the id_cols list is empty

Enhancements:
- Document empty id_cols behavior in the check_traceability docstring

Tests:
- Add a test to ensure check_traceability rejects empty identifier lists by raising ValueError