### PR TITLE
Use sys.path instead of PYTHONPATH in run_gui

### DIFF
--- a/run_gui.py
+++ b/run_gui.py
@@ -7,8 +7,8 @@ if __name__ == '__main__':
     # Get the project root directory
     project_root = os.path.dirname(os.path.abspath(__file__))
     
-    # Set PYTHONPATH to include the project root
-    os.environ['PYTHONPATH'] = project_root
+    # Add project root to the module search path
+    sys.path.append(project_root)
     
     # Import and run the main function
     from src.gui import main


### PR DESCRIPTION
## Summary
- Avoid overwriting PYTHONPATH by appending project root to sys.path in run_gui

## Testing
- `pytest -q`
- `python run_gui.py` (fails: ModuleNotFoundError: st_aggrid; attempted `pip install streamlit-aggrid` but installation failed with 403)

## Summary by Sourcery

Bug Fixes:
- Prevent run_gui from overwriting PYTHONPATH by using sys.path.append to include the project root