### PR TITLE
Fix ReportLab md5 compatibility

### DIFF
--- a/src/reporting.py
+++ b/src/reporting.py
@@ -8,6 +8,7 @@ from reportlab.lib.units import inch
 import os
 import hashlib
 from reportlab.pdfbase import pdfdoc
+from reportlab.lib import utils as reportlab_utils
 
 # ---------------------------------------------------------------------------
 # ReportLab uses ``hashlib.md5(usedforsecurity=False)`` when building PDF files
@@ -26,6 +27,14 @@ except TypeError:  # Fallback for Python versions without the keyword
         return hashlib.md5(data)
 
     pdfdoc.md5 = _md5_compat
+    reportlab_utils.md5 = _md5_compat
+
+    def _digester_compat(s):
+        return hashlib.md5(
+            s if reportlab_utils.isBytes(s) else s.encode("utf8")
+        ).hexdigest()
+
+    reportlab_utils._digester = _digester_compat
 
 def generate_qc_report(
     validation_results,


### PR DESCRIPTION
## Summary
- ensure ReportLab's MD5 helper works on Python versions without `usedforsecurity`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893ce6e28fc83279c700a1b8cf23ab3