### PR TITLE
fix logging module import in test script

### DIFF
--- a/scripts/test_real_data_all_in_one.py
+++ b/scripts/test_real_data_all_in_one.py
@@ -30,6 +30,12 @@ import csv
 import pandas as pd
 import yaml
 
+# Ensure the repository's ``src`` directory is on ``sys.path`` so that
+# ``logging_module`` can be imported when running this script directly
+# without installing the package.
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(SCRIPT_DIR, '..', 'src'))
+
 from logging_module import setup_logging, log_activity
 
 


### PR DESCRIPTION
## Summary
- ensure `test_real_data_all_in_one.py` can import `logging_module` by adding the repository's `src` directory to `sys.path`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893e0779be483278a09bda531ddce1d