### PR TITLE
Fix PhenoQC console entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,10 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name='PhenoQC',
     version='1.0.0',
-    packages=[
-        'phenoqc',
-        'phenoqc.gui',
-        'phenoqc.utils',
-    ],
-    package_dir={
-        'phenoqc': 'src',
-        'phenoqc.gui': 'src/gui',
-        'phenoqc.utils': 'src/utils',
-    },
+    packages=find_packages(where="src"),
+    package_dir={"": "src"},
     install_requires=[
         'pandas',
         'jsonschema',
@@ -34,10 +26,7 @@ setup(
         'ucimlrepo',
     ],
     extras_require={
-        'test': [
-            'pytest',
-            'unittest',
-        ],
+        'test': ['pytest'],
     },
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,18 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(
     name='PhenoQC',
     version='1.0.0',
-    packages=find_packages(where='src'),
-    package_dir={'': 'src'},
+    packages=[
+        'phenoqc',
+        'phenoqc.gui',
+        'phenoqc.utils',
+    ],
+    package_dir={
+        'phenoqc': 'src',
+        'phenoqc.gui': 'src/gui',
+        'phenoqc.utils': 'src/utils',
+    },
     install_requires=[
         'pandas',
         'jsonschema',
@@ -33,7 +41,7 @@ setup(
     },
     entry_points={
         'console_scripts': [
-            'phenoqc=cli:main',
+            'phenoqc=phenoqc.cli:main',
         ],
     },
     package_data={


### PR DESCRIPTION
## Summary
- map source files to a proper `phenoqc` package
- point console script entry to `phenoqc.cli:main` so relative imports resolve

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `pytest -q`

## Summary by Sourcery

Fix the PhenoQC console entry point and map source files to the proper phenoqc package for correct relative imports

Bug Fixes:
- Point console script entry to phenoqc.cli:main to resolve relative imports

Enhancements:
- Map source files into the phenoqc package