### PR TITLE
Refactor range check to use list comprehension

### DIFF
--- a/src/quality_metrics.py
+++ b/src/quality_metrics.py
@@ -37,14 +37,18 @@ def check_accuracy(df: pd.DataFrame, schema_cfg: Dict[str, Any]) -> pd.DataFrame
         if max_val is not None:
             mask |= series > max_val
         offending = df.loc[mask, col]
-        for idx, value in offending.items():
-            records.append({
-                "row": idx,
-                "column": col,
-                "value": value,
-                "minimum": min_val,
-                "maximum": max_val,
-            })
+        records.extend(
+            [
+                {
+                    "row": idx,
+                    "column": col,
+                    "value": value,
+                    "minimum": min_val,
+                    "maximum": max_val,
+                }
+                for idx, value in offending.items()
+            ]
+        )
     return pd.DataFrame(records)
 
 


### PR DESCRIPTION
## Summary
- simplify accuracy check by using records.extend with a list comprehension

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894a8a31a6c8327a597294b204e780f

## Summary by Sourcery

Enhancements:
- Replace manual loop in check_accuracy with a list comprehension for extending records