### PR TITLE
ci: run tests on Python 3.9+

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- drop Python 3.8 from test workflow so CI runs on Python 3.9+

## Testing
- `python -m pip install --upgrade pip`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement streamlit-aggrid)*
- `pip install pytest pytest-cov` *(fails: Could not find a version that satisfies the requirement pytest-cov)*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894dfaa83bc83279e4be40c79cbeb95