### PR TITLE
test: expand coverage for config and logging

### DIFF
--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,56 @@
+import unittest
+import tempfile
+import os
+import json
+import yaml
+
+from src.configuration import load_config, save_config
+
+
+class TestConfigurationModule(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.config = {"param1": 10, "param2": [1, 2, 3]}
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_load_config_yaml_and_json(self):
+        yaml_path = os.path.join(self.temp_dir.name, "config.yaml")
+        json_path = os.path.join(self.temp_dir.name, "config.json")
+        with open(yaml_path, "w") as f:
+            yaml.safe_dump(self.config, f)
+        with open(json_path, "w") as f:
+            json.dump(self.config, f)
+
+        self.assertEqual(load_config(yaml_path), self.config)
+        self.assertEqual(load_config(json_path), self.config)
+
+        with open(yaml_path, "r") as f:
+            self.assertEqual(load_config(f), self.config)
+        with open(json_path, "r") as f:
+            self.assertEqual(load_config(f), self.config)
+
+    def test_save_config_yaml_and_json(self):
+        yaml_path = os.path.join(self.temp_dir.name, "saved.yaml")
+        json_path = os.path.join(self.temp_dir.name, "saved.json")
+        save_config(self.config, yaml_path)
+        save_config(self.config, json_path)
+
+        with open(yaml_path) as f:
+            self.assertEqual(yaml.safe_load(f), self.config)
+        with open(json_path) as f:
+            self.assertEqual(json.load(f), self.config)
+
+    def test_invalid_extension(self):
+        invalid_path = os.path.join(self.temp_dir.name, "config.txt")
+        with open(invalid_path, "w") as f:
+            f.write("test")
+        with self.assertRaises(ValueError):
+            load_config(invalid_path)
+        with self.assertRaises(ValueError):
+            save_config(self.config, invalid_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_logging_module.py
+++ b/tests/test_logging_module.py
@@ -1,0 +1,48 @@
+import unittest
+import tempfile
+import os
+
+from src.logging_module import setup_logging, log_activity
+
+
+class TestLoggingModule(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir.name)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        self.temp_dir.cleanup()
+
+    def test_setup_logging_creates_file_and_logs(self):
+        setup_logging()
+        logs_dir = os.path.join(self.temp_dir.name, "logs")
+        files = os.listdir(logs_dir)
+        self.assertEqual(len(files), 1)
+        log_file = os.path.join(logs_dir, files[0])
+
+        log_activity("info message")
+        log_activity("warn message", level="warning")
+
+        with open(log_file) as f:
+            content = f.read()
+        self.assertIn("info message", content)
+        self.assertIn("warn message", content)
+
+    def test_custom_log_file_and_append_mode(self):
+        log_name = "test.log"
+        setup_logging(log_name)
+        log_activity("first")
+        setup_logging(log_name, mode="a")
+        log_activity("second")
+
+        log_path = os.path.join(self.temp_dir.name, "logs", log_name)
+        with open(log_path) as f:
+            content = f.read()
+        self.assertIn("first", content)
+        self.assertIn("second", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests for loading and saving configuration files
- add tests covering logging initialization and message recording

## Testing
- `pytest tests/test_configuration.py tests/test_logging_module.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894e503dcc08327b8b9ba418e416503