### PR TITLE
Update imports for phenoqc package

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -6,7 +6,7 @@ This section provides detailed API documentation for PhenoQC's modules.
 Validation Module
 ----------------------------------------------------
 
-.. automodule:: src.validation
+.. automodule:: phenoqc.validation
    :members:
    :undoc-members:
    :show-inheritance:
@@ -14,7 +14,7 @@ Validation Module
 Mapping Module
 -------------
 
-.. automodule:: src.mapping
+.. automodule:: phenoqc.mapping
    :members:
    :undoc-members:
    :show-inheritance:
@@ -22,7 +22,7 @@ Mapping Module
 Missing Data Module
 -----------------
 
-.. automodule:: src.missing_data
+.. automodule:: phenoqc.missing_data
    :members:
    :undoc-members:
    :show-inheritance:
@@ -30,7 +30,7 @@ Missing Data Module
 Batch Processing Module
 ---------------------
 
-.. automodule:: src.batch_processing
+.. automodule:: phenoqc.batch_processing
    :members:
    :undoc-members:
    :show-inheritance:
@@ -38,7 +38,7 @@ Batch Processing Module
 Input Module
 -----------
 
-.. automodule:: src.input
+.. automodule:: phenoqc.input
    :members:
    :undoc-members:
    :show-inheritance:
@@ -46,7 +46,7 @@ Input Module
 Reporting Module
 --------------
 
-.. automodule:: src.reporting
+.. automodule:: phenoqc.reporting
    :members:
    :undoc-members:
    :show-inheritance:
@@ -54,7 +54,7 @@ Reporting Module
 Configuration Module
 ------------------
 
-.. automodule:: src.configuration
+.. automodule:: phenoqc.configuration
    :members:
    :undoc-members:
    :show-inheritance:
@@ -62,7 +62,7 @@ Configuration Module
 Logging Module
 -------------
 
-.. automodule:: src.logging_module
+.. automodule:: phenoqc.logging_module
    :members:
    :undoc-members:
-   :show-inheritance: 
+   :show-inheritance:

--- a/run_gui.py
+++ b/run_gui.py
@@ -6,23 +6,25 @@ import subprocess
 if __name__ == '__main__':
     # Get the project root directory
     project_root = os.path.dirname(os.path.abspath(__file__))
-    
-    # Set PYTHONPATH to include the project root
-    os.environ['PYTHONPATH'] = project_root
-    
+
+    # Add the 'src' directory to PYTHONPATH and sys.path for imports
+    src_path = os.path.join(project_root, 'src')
+    os.environ['PYTHONPATH'] = src_path
+    sys.path.insert(0, src_path)
+
     # Import and run the main function
-    from src.gui import main
-    
+    from phenoqc.gui import main
+
     # Create a temporary file with the main function call
     import tempfile
-    
+
     with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
-        f.write('from src.gui import main\nif __name__ == "__main__":\n    main()')
+        f.write('from phenoqc.gui import main\nif __name__ == "__main__":\n    main()')
         temp_path = f.name
-    
+
     try:
         # Run streamlit using the temporary file
         subprocess.run(["streamlit", "run", temp_path])
     finally:
         # Clean up the temporary file
-        os.unlink(temp_path) 
+        os.unlink(temp_path)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4,7 +4,7 @@ import os
 import json
 import yaml
 
-from src.configuration import load_config, save_config
+from phenoqc.configuration import load_config, save_config
 
 
 class TestConfigurationModule(unittest.TestCase):

--- a/tests/test_logging_module.py
+++ b/tests/test_logging_module.py
@@ -2,7 +2,7 @@ import unittest
 import tempfile
 import os
 
-from src.logging_module import setup_logging, log_activity
+from phenoqc.logging_module import setup_logging, log_activity
 
 
 class TestLoggingModule(unittest.TestCase):


### PR DESCRIPTION
## Summary
- replace outdated `src` imports with `phenoqc` package across tests and docs
- adjust GUI runner to load modules from `phenoqc`

## Testing
- `pytest -v tests/`
- Attempted `pip install pytest-cov` (failed: ProxyError: Cannot connect to proxy.)

## Summary by Sourcery

Switch all imports from the local src directory to the phenoqc package and update the GUI runner to load modules correctly.

Enhancements:
- Replace all src.* imports with phenoqc.* across code, tests, and documentation
- Modify run_gui script to set PYTHONPATH and sys.path to the src directory and import phenoqc.gui.main
- Update temporary file generation in run_gui to reference phenoqc.gui.main