### PR TITLE
Define explicit package mapping in setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,14 @@
-from setuptools import find_packages, setup
+from setuptools import setup
 
 setup(
     name='PhenoQC',
     version='1.0.0',
-    packages=find_packages(where="src"),
-    package_dir={"": "src"},
+    packages=["phenoqc", "phenoqc.gui", "phenoqc.utils"],
+    package_dir={
+        "phenoqc": "src",
+        "phenoqc.gui": "src/gui",
+        "phenoqc.utils": "src/utils",
+    },
     install_requires=[
         'pandas',
         'jsonschema',


### PR DESCRIPTION
## Summary
- Replace dynamic package discovery with an explicit package list for `phenoqc`, its `gui`, and `utils` subpackages.
- Map each package to its source directory and retain the existing CLI entry point.

## Testing
- `pip install -e . --no-build-isolation` *(fails: invalid command 'bdist_wheel')*
- `python setup.py develop`
- `phenoqc --help`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68951ee27be883279efbaea353737d57

## Summary by Sourcery

Replace dynamic package discovery with an explicit package list and package_dir mapping in setup.py for phenoqc and its subpackages

Enhancements:
- Switch from find_packages to an explicit listing of phenoqc, phenoqc.gui, and phenoqc.utils packages
- Retain the existing CLI entry point configuration

Build:
- Map each package explicitly to its src directory in setup.py instead of relying on automated discovery