### PR TITLE
Handle package imports when running cli directly

### DIFF
--- a/src/phenoqc/cli.py
+++ b/src/phenoqc/cli.py
@@ -9,26 +9,20 @@ if __package__:
     from .batch_processing import batch_process
     from .logging_module import setup_logging, log_activity
     from .utils.zip_utils import extract_zip
-else:  # pragma: no cover - allows execution without installation
+else:
     from importlib import import_module
-    import types
+    import types, os, sys
     current_dir = os.path.dirname(os.path.abspath(__file__))
     if current_dir not in sys.path:
         sys.path.insert(0, current_dir)
-    if "phenoqc" not in sys.modules:
-        pkg = types.ModuleType("phenoqc")
-        pkg.__path__ = [current_dir]
-        sys.modules["phenoqc"] = pkg
-
-    def _dynamic_imports():
-        batch_process = import_module("phenoqc.batch_processing").batch_process
-        logging_mod = import_module("phenoqc.logging_module")
-        setup_logging = logging_mod.setup_logging
-        log_activity = logging_mod.log_activity
-        extract_zip = import_module("phenoqc.utils.zip_utils").extract_zip
-        return batch_process, setup_logging, log_activity, extract_zip
-
-    batch_process, setup_logging, log_activity, extract_zip = _dynamic_imports()
+    pkg = types.ModuleType("phenoqc")
+    pkg.__path__ = [current_dir]
+    sys.modules["phenoqc"] = pkg
+    batch_process = import_module("phenoqc.batch_processing").batch_process
+    logging_mod = import_module("phenoqc.logging_module")
+    setup_logging = logging_mod.setup_logging
+    log_activity = logging_mod.log_activity
+    extract_zip = import_module("phenoqc.utils.zip_utils").extract_zip
 
 SUPPORTED_EXTENSIONS = {'.csv', '.tsv', '.json', '.zip'}
 


### PR DESCRIPTION
## Summary
- Allow CLI to run both as part of the phenoqc package and as a standalone script by dynamically creating a package context when `__package__` is not set.

## Testing
- `phenoqc --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689528cc2d988327bfb17d3a131ad0d8

## Summary by Sourcery

Allow the CLI to be executed directly from source by dynamically injecting a phenoqc package context when __package__ is unset and simplifying import logic

Enhancements:
- Inject a phenoqc ModuleType into sys.modules with its __path__ set to the source directory for standalone execution
- Ensure the source directory is prepended to sys.path when running the CLI directly
- Inline and simplify dynamic imports for batch processing, logging, and zip utilities instead of using a helper function