### PR TITLE
Refactor CLI imports

### DIFF
--- a/src/phenoqc/cli.py
+++ b/src/phenoqc/cli.py
@@ -1,28 +1,11 @@
 import argparse
 import json
 import os
-import sys
 import datetime
 
-# Support running both as a module (with package context) and as a script.
-if __package__:
-    from .batch_processing import batch_process
-    from .logging_module import setup_logging, log_activity
-    from .utils.zip_utils import extract_zip
-else:
-    from importlib import import_module
-    import types, os, sys
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    if current_dir not in sys.path:
-        sys.path.insert(0, current_dir)
-    pkg = types.ModuleType("phenoqc")
-    pkg.__path__ = [current_dir]
-    sys.modules["phenoqc"] = pkg
-    batch_process = import_module("phenoqc.batch_processing").batch_process
-    logging_mod = import_module("phenoqc.logging_module")
-    setup_logging = logging_mod.setup_logging
-    log_activity = logging_mod.log_activity
-    extract_zip = import_module("phenoqc.utils.zip_utils").extract_zip
+from phenoqc.batch_processing import batch_process
+from phenoqc.logging_module import setup_logging, log_activity
+from phenoqc.utils.zip_utils import extract_zip
 
 SUPPORTED_EXTENSIONS = {'.csv', '.tsv', '.json', '.zip'}
 


### PR DESCRIPTION
## Summary
- use absolute imports in CLI for batch processing, logging, and zip utilities
- remove custom `__package__` import fallback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689533296d6c8327a449a79d2de331ad