### PR TITLE
Add module entry point for PhenoQC CLI

### DIFF
--- a/src/phenoqc/__main__.py
+++ b/src/phenoqc/__main__.py
@@ -1,1 +1,13 @@
- 
+"""Entry point for running PhenoQC as a module.
+
+This module simply forwards execution to the CLI ``main`` function so that
+``python -m phenoqc`` behaves the same as invoking the ``phenoqc`` command
+directly.
+"""
+
+from phenoqc.cli import main
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- Add `__main__` module that forwards execution to the existing CLI `main` function

## Testing
- `python setup.py develop`
- `phenoqc --help`
- `python -m phenoqc --help`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68953745e73083279310faa42ba5196b

## Summary by Sourcery

New Features:
- Introduce src/phenoqc/__main__.py as a module entry point that forwards to the existing CLI main function to support python -m phenoqc