### PR TITLE
Mirror console script entry in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,13 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "phenoqc"
+version = "1.0.0"
+requires-python = ">=3.9"
+description = "Phenotypic Data Quality Control Toolkit for Genomic Data Infrastructure (GDI)"
+readme = "README.md"
+
+[project.scripts]
+phenoqc = "phenoqc.cli:main"


### PR DESCRIPTION
## Summary
- Mirror the phenoqc console script in pyproject.toml so the CLI resolves to `phenoqc.cli:main`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68953f0875008327b06360c1c897a645