### PR TITLE
docs: clarify installation and CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,29 @@
 
 PhenoQC requires Python 3.9+.
 
-**Using `pip`:**
+### Fresh install
+
+Install from PyPI:
 
 ```bash
 pip install phenoqc
 ```
 
-Or **manually** from source:
+### From source
+
+Clone the repository and install in editable mode:
 
 ```bash
 git clone https://github.com/jorgeMFS/PhenoQC.git
 cd PhenoQC
 pip install -e .
+```
+
+Running the CLI directly from the uninstalled `src/` tree will fail. For local
+development without installation you can use:
+
+```bash
+python -m phenoqc.cli
 ```
 
 **Dependencies** are listed in `requirements.txt` and include:


### PR DESCRIPTION
## Summary
- document fresh PyPI install and editable source install
- warn that invoking CLI from uninstalled src tree fails; suggest `python -m phenoqc.cli`

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'pandas')

------
https://chatgpt.com/codex/tasks/task_e_6895409107c0832790065460ec98cf67

## Summary by Sourcery

Clarify installation instructions in the README and warn about invoking the CLI from an uninstalled source tree

Documentation:
- Split installation instructions into separate “Fresh install” and “From source” sections
- Add a note that running the CLI directly from the uninstalled src tree fails and suggest using python -m phenoqc.cli