### PR TITLE
Expand mapping and batch processing tests

### DIFF
--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -173,5 +173,11 @@ synonym: "Bronchial disease" EXACT []
             with self.assertRaises(RuntimeError):
                 _safe_md5_hexdigest(data)
 
+        # Test with empty data input
+        empty_data = b''
+        expected_empty = hashlib.md5(empty_data).hexdigest()
+        with patch('hashlib.new', side_effect=TypeError):
+            self.assertEqual(_safe_md5_hexdigest(empty_data), expected_empty)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -146,6 +146,14 @@ synonym: "Bronchial disease" EXACT []
         self.assertEqual(get_file_type('data.csv'), 'csv')
         self.assertEqual(get_file_type('data.tsv'), 'tsv')
         self.assertEqual(get_file_type('data.json'), 'json')
+        # Test uppercase extensions
+        self.assertEqual(get_file_type('data.CSV'), 'csv')
+        self.assertEqual(get_file_type('data.TSV'), 'tsv')
+        self.assertEqual(get_file_type('data.JSON'), 'json')
+        # Test mixed-case extensions
+        self.assertEqual(get_file_type('data.CsV'), 'csv')
+        self.assertEqual(get_file_type('data.TsV'), 'tsv')
+        self.assertEqual(get_file_type('data.JsOn'), 'json')
         with self.assertRaises(ValueError):
             get_file_type('data.txt')
 

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -2,7 +2,16 @@ import unittest
 import os
 import json
 import tempfile
-from phenoqc.batch_processing import batch_process, unique_output_name
+import hashlib
+from unittest.mock import patch
+
+from phenoqc.batch_processing import (
+    batch_process,
+    unique_output_name,
+    convert_nans_to_none_for_string_cols,
+    get_file_type,
+    _safe_md5_hexdigest,
+)
 from phenoqc.configuration import load_config
 import pandas as pd
 
@@ -132,6 +141,37 @@ synonym: "Bronchial disease" EXACT []
         self.assertEqual(config['imputation_strategies']['Age'], 'median')
         self.assertEqual(config['imputation_strategies']['Gender'], 'mode')
         self.assertEqual(config['imputation_strategies']['Measurement'], 'mean')
+
+    def test_get_file_type(self):
+        self.assertEqual(get_file_type('data.csv'), 'csv')
+        self.assertEqual(get_file_type('data.tsv'), 'tsv')
+        self.assertEqual(get_file_type('data.json'), 'json')
+        with self.assertRaises(ValueError):
+            get_file_type('data.txt')
+
+    def test_convert_nans_to_none_for_string_cols(self):
+        df = pd.DataFrame({'name': ['Alice', float('nan')], 'age': [30, float('nan')]})
+        schema = {'properties': {'name': {'type': ['string', 'null']}, 'age': {'type': 'number'}}}
+        converted = convert_nans_to_none_for_string_cols(df, schema)
+        self.assertIsNone(converted.loc[1, 'name'])
+        self.assertTrue(pd.isna(converted.loc[1, 'age']))
+
+    def test_unique_output_name_stability(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = '/any/path/sample.json'
+            first = unique_output_name(path, tmpdir, suffix='_report.pdf')
+            second = unique_output_name(path, tmpdir, suffix='_report.pdf')
+            self.assertEqual(first, second)
+            self.assertTrue(first.endswith('_json_report.pdf'))
+
+    def test_safe_md5_hexdigest_fallback(self):
+        data = b'test-data'
+        expected = hashlib.md5(data).hexdigest()
+        with patch('hashlib.new', side_effect=TypeError):
+            self.assertEqual(_safe_md5_hexdigest(data), expected)
+        with patch('hashlib.new', side_effect=TypeError), patch('hashlib.md5', side_effect=ValueError):
+            with self.assertRaises(RuntimeError):
+                _safe_md5_hexdigest(data)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -307,5 +307,19 @@ default_ontologies: [HPO]
         with self.assertRaises(FileNotFoundError):
             OntologyMapper(missing_config_file)
 
+    def test_map_term_handles_non_string(self):
+        """Ensure non-string inputs are handled gracefully."""
+        result_none = self.mapper.map_term(None)
+        self.assertTrue(all(v is None for v in result_none.values()))
+
+        result_numeric = self.mapper.map_term(12345)
+        self.assertTrue(all(v is None for v in result_numeric.values()))
+
+    def test_map_term_fuzzy_matching(self):
+        """Terms with minor misspellings should still map using fuzzy matching."""
+        result = self.mapper.map_term("Hypertention")
+        self.assertEqual(result["HPO"], "HP:0000822")
+        self.assertEqual(result["DO"], "DOID:0050167")
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -321,5 +321,10 @@ default_ontologies: [HPO]
         self.assertEqual(result["HPO"], "HP:0000822")
         self.assertEqual(result["DO"], "DOID:0050167")
 
+    def test_map_term_fuzzy_matching_negative(self):
+        """Terms too dissimilar to any known term should not map via fuzzy matching."""
+        result = self.mapper.map_term("Xyzzypopple")
+        self.assertTrue(all(v is None for v in result.values()))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add tests for `OntologyMapper` to handle non-string inputs and fuzzy matching
- add tests for `batch_processing` helpers like file type detection, NaN conversion, unique output naming, and FIPS-safe MD5

## Testing
- `pytest tests/test_mapping.py tests/test_batch_processing.py` *(fails: No module named 'yaml', No module named 'pandas')*

## Summary by Sourcery

Expand unit test coverage for batch processing utilities and ontology mapping to validate file type detection, NaN handling, output naming stability, safe MD5 hashing, and robust term mapping

Tests:
- Add tests for batch_processing helpers: file type detection, NaN conversion for string columns, unique output naming, and safe MD5 fallback
- Add tests for OntologyMapper.map_term to handle non-string inputs and fuzzy matching of misspelled terms