### PR TITLE
Allow CLI quality metrics for redundancy, traceability and timeliness

### DIFF
--- a/scripts/quality_metrics_cli_test.py
+++ b/scripts/quality_metrics_cli_test.py
@@ -20,6 +20,8 @@ from datetime import datetime, timedelta
 import pandas as pd
 import yaml
 
+from phenoqc.quality_metrics import QUALITY_METRIC_CHOICES
+
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 BASE_CONFIG = os.path.join(SCRIPT_DIR, "config", "config.yaml")
 SCHEMA_PATH = os.path.join(SCRIPT_DIR, "config", "schema.json")
@@ -74,11 +76,7 @@ def run_phenoqc(data_path: str, cfg_path: str, output_dir: str) -> None:
         "--output",
         output_dir,
         "--quality-metrics",
-        "accuracy",
-        "redundancy",
-        "traceability",
-        "timeliness",
-    ]
+    ] + QUALITY_METRIC_CHOICES
     print("[INFO] Running:", " ".join(cmd))
     proc = subprocess.run(cmd, capture_output=True, text=True)
     print("[STDOUT]\n", proc.stdout)

--- a/src/phenoqc/batch_processing.py
+++ b/src/phenoqc/batch_processing.py
@@ -16,6 +16,7 @@ from .configuration import load_config
 from .logging_module import log_activity, setup_logging
 from tqdm import tqdm
 import hashlib
+from .quality_metrics import QUALITY_METRIC_CHOICES
 
 
 def _safe_md5_hexdigest(data: bytes) -> str:
@@ -724,12 +725,7 @@ def batch_process(
     # 2) Load config
     config = load_config(config_path)
     if quality_metrics is not None:
-        allowed_metrics = {
-            "precision",
-            "recall",
-            "f1",
-            "accuracy",
-        }  # <-- update as needed
+        allowed_metrics = set(QUALITY_METRIC_CHOICES)
         invalid_metrics = [m for m in quality_metrics if m not in allowed_metrics]
         if invalid_metrics:
             raise ValueError(

--- a/src/phenoqc/cli.py
+++ b/src/phenoqc/cli.py
@@ -6,6 +6,7 @@ import datetime
 from phenoqc.batch_processing import batch_process
 from phenoqc.logging_module import setup_logging, log_activity
 from phenoqc.utils.zip_utils import extract_zip
+from phenoqc.quality_metrics import QUALITY_METRIC_CHOICES
 
 SUPPORTED_EXTENSIONS = {'.csv', '.tsv', '.json', '.zip'}
 
@@ -43,7 +44,7 @@ def parse_arguments():
     parser.add_argument(
         '--quality-metrics',
         nargs='+',
-        choices=['accuracy', 'redundancy', 'traceability', 'timeliness', 'all'],
+        choices=QUALITY_METRIC_CHOICES + ['all'],
         help='Additional quality metrics to evaluate',
         default=None
     )
@@ -56,7 +57,7 @@ def parse_arguments():
         args.phenotype_column = None  # Clear the old argument
 
     if args.quality_metrics and 'all' in args.quality_metrics:
-        args.quality_metrics = ['accuracy', 'redundancy', 'traceability', 'timeliness']
+        args.quality_metrics = QUALITY_METRIC_CHOICES
 
     return args
 

--- a/src/phenoqc/gui/views.py
+++ b/src/phenoqc/gui/views.py
@@ -1,6 +1,8 @@
 from typing import List, Dict
 
-QUALITY_OPTIONS = ["accuracy", "redundancy", "traceability", "timeliness", "all"]
+from ..quality_metrics import QUALITY_METRIC_CHOICES
+
+QUALITY_OPTIONS = QUALITY_METRIC_CHOICES + ["all"]
 
 def build_quality_metrics_widget(cfg: Dict) -> Dict:
     """Return widget configuration for quality metrics selection.

--- a/src/phenoqc/quality_metrics.py
+++ b/src/phenoqc/quality_metrics.py
@@ -2,6 +2,14 @@ import pandas as pd
 import hashlib
 from typing import List, Optional, Dict, Any
 
+# Central list of quality metric identifiers used across the application.
+QUALITY_METRIC_CHOICES = [
+    "accuracy",
+    "redundancy",
+    "traceability",
+    "timeliness",
+]
+
 
 def check_accuracy(df: pd.DataFrame, schema_cfg: Dict[str, Any]) -> pd.DataFrame:
     """Check values fall within schema-defined ranges.

--- a/src/phenoqc/validation.py
+++ b/src/phenoqc/validation.py
@@ -10,6 +10,7 @@ from .quality_metrics import (
     detect_redundancy,
     check_traceability,
     check_timeliness,
+    QUALITY_METRIC_CHOICES,
 )
 
 class DataValidator:
@@ -389,12 +390,7 @@ class DataValidator:
         if cfg and cfg.get("quality_metrics"):
             metrics = cfg["quality_metrics"]
             if "all" in metrics:
-                metrics = [
-                    "accuracy",
-                    "redundancy",
-                    "traceability",
-                    "timeliness",
-                ]
+                metrics = QUALITY_METRIC_CHOICES
             if "accuracy" in metrics:
                 results["Accuracy Issues"] = check_accuracy(self.df, self.schema)
             if "redundancy" in metrics:


### PR DESCRIPTION
## Summary
- centralize allowed quality metrics into a single `QUALITY_METRIC_CHOICES` constant
- reuse the shared constant across CLI, batch processing, validation, GUI and example script

## Testing
- `pytest tests/test_quality_metrics.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas (403 Forbidden))*
- `python scripts/quality_metrics_cli_test.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

## Summary by Sourcery

Centralize quality metric definitions into a shared constant and replace hard-coded metric lists across the CLI, batch processing, validation, GUI, and example script to ensure consistency.

Enhancements:
- Define QUALITY_METRIC_CHOICES as the single source of allowed metrics
- Refactor CLI, batch processing, validation, GUI, and example script to use the shared constant instead of hard-coded lists