### PR TITLE
Enable quality metric checks in default configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,3 +34,13 @@ advanced_imputation_methods:
   - IterativeSVD
 
 cache_expiry_days: 30
+
+quality_metrics:
+  - accuracy
+  - redundancy
+  - traceability
+  - timeliness
+
+date_col: VisitDate
+max_lag_days: 5
+source_column: SampleID


### PR DESCRIPTION
## Summary
- add quality_metrics list to config
- configure required fields for timeliness and traceability metrics

## Testing
- `pytest tests/test_quality_metrics.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas -q` *(fails: Could not find a version that satisfies the requirement pandas (proxy 403))*

------
https://chatgpt.com/codex/tasks/task_e_68955004b1bc8327a52c289e1ad7aa76

## Summary by Sourcery

Enable quality metric checks by extending the default configuration with a list of metrics and their required parameters.

New Features:
- Add quality_metrics list with accuracy, redundancy, traceability, and timeliness to config

Enhancements:
- Configure default date_col, max_lag_days, and source_column parameters for timeliness and traceability metrics