### PR TITLE
Persist per-file quality metrics artifacts and extend CLI test to val…

### DIFF
--- a/src/phenoqc/batch_processing.py
+++ b/src/phenoqc/batch_processing.py
@@ -637,7 +637,7 @@ def process_file(
                         json.dump(metrics_summary, jf, indent=2)
                 except Exception as _persist_ex:
                     log_activity(
-                        f"{file_path}: Failed to persist quality metrics artifacts: {_persist_ex}",
+                        f"{file_path}: Failed to persist quality metrics artifacts [{type(_persist_ex).__name__}]: {_persist_ex}",
                         level="warning",
                     )
 


### PR DESCRIPTION
## Summary

Persist per-file quality metrics artifacts and extend the CLI test to verify them

New Features:
- Persist per-file TSV and JSON summary files for accuracy, redundancy, traceability, and timeliness when enabled in config

Tests:
- Extend CLI test to assert that quality metrics TSV and JSON artifacts exist and validate that per-metric row counts in the TSV match the JSON summary